### PR TITLE
landscape: fix system preferences scrolling

### DIFF
--- a/ui/src/preferences/SystemPreferences.tsx
+++ b/ui/src/preferences/SystemPreferences.tsx
@@ -108,7 +108,7 @@ export const SystemPreferences = (
     >
       <div className="system-preferences-grid bg-gray-50">
         <Route exact={isMobile} path={match.url}>
-          <aside className="system-preferences-aside min-h-fit max-h-[85vh] w-full min-w-60 flex flex-col border-r-2 border-gray-50 bg-white py-4 font-semibold text-black sm:w-auto sm:py-8 sm:text-gray-600">
+          <aside className="system-preferences-aside min-h-fit max-h-[calc(100vh-6.25rem)] w-full min-w-60 flex flex-col border-r-2 border-gray-50 bg-white py-4 font-semibold text-black sm:w-auto sm:py-8 sm:text-gray-600">
             <nav className="flex flex-col px-2 sm:px-6">
               <SearchSystemPreferences subUrl={subUrl} />
               <span className="pt-1 pl-2 pb-3 text-sm font-semibold text-gray-400">
@@ -212,7 +212,7 @@ export const SystemPreferences = (
           </aside>
         </Route>
         <Route path={settingsPath}>
-          <section className="system-preferences-content flex min-h-[60vh] flex-1 flex-col bg-gray-50 p-4 text-gray-800 sm:p-8">
+          <section className="system-preferences-content min-h-fit max-h-[calc(100vh-6.25rem)] flex-1 flex-col bg-gray-50 p-4 text-gray-800 sm:p-8">
             <Switch>
               <Route path={`${match.url}/apps/:desk`} component={AppPrefs} />
               <Route path={`${match.url}/help`} component={Help} />

--- a/ui/src/styles/grids.css
+++ b/ui/src/styles/grids.css
@@ -65,16 +65,18 @@
 }
 
 
-.system-preferences-grid {
-  display: grid;
-  grid-template-columns: 20rem 1fr;
-  grid-template-rows: auto;
+@media (min-width: 640px){
+  .system-preferences-grid {
+    display: grid;
+    grid-template-columns: 20rem 1fr;
+    grid-template-rows: auto;
+  }
 }
 
 .system-preferences-aside {
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .system-preferences-content {
-  overflow-y: scroll;
+  overflow-y: auto;
 }


### PR DESCRIPTION
Changes the max-height of the aside and main sections to match the height of the modal itself. Also adds a media query to fix a mobile regression.

A quick demo:

https://user-images.githubusercontent.com/748181/208215555-13d42ea7-9400-4de9-b7d9-054d9d3f861c.mov



