### PR TITLE
grid: update app ref

### DIFF
--- a/ui/src/components/AppInfo.tsx
+++ b/ui/src/components/AppInfo.tsx
@@ -61,7 +61,7 @@ export const AppInfo: FC<AppInfoProps> = ({ docket, pike, className }) => {
 
   const copyApp = useCallback(() => {
     setCopied(true);
-    clipboardCopy(`web+urbitgraph://${publisher}/${desk}`);
+    clipboardCopy(`/1/desk/${publisher}/${desk}`);
 
     setTimeout(() => {
       setCopied(false);


### PR DESCRIPTION
Copy button uses the new app ref schema (`/1/desk/ship/desk`) for easy paste-ability in Groups 2