### PR TITLE
Handle kelvin update error cases

### DIFF
--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -1,4 +1,4 @@
-:~  title+'System'
+:~  title+'Grid'
     info+'An app launcher for Urbit.'
     color+0xee.5432
     glob-http+['https://bootstrap.urbit.org/glob-0v1.tqd6t.ggt8r.roheb.l3bvq.sbm6d.glob' 0v1.tqd6t.ggt8r.roheb.l3bvq.sbm6d]

--- a/ui/src/components/ErrorAlert.tsx
+++ b/ui/src/components/ErrorAlert.tsx
@@ -17,7 +17,7 @@ const SubmitIssue = ({ error }: { error: Error }) => {
     <Button
       as="a"
       variant="caution"
-      href={`https://github.com/urbit/landscape/issues/new?assignees=&labels=bug&title=${title}&body=${body}`}
+      href={`https://github.com/tloncorp/landscape-apps/issues/new?assignees=&labels=bug&title=${title}&body=${body}`}
       target="_blank"
       rel="noreferrer"
     >

--- a/ui/src/preferences/SystemPreferences.tsx
+++ b/ui/src/preferences/SystemPreferences.tsx
@@ -72,7 +72,6 @@ export const SystemPreferences = (
   const { systemBlocked } = useSystemUpdate();
   const charges = useCharges();
   const filteredCharges = Object.values(charges)
-    .filter((charge) => charge.desk !== window.desk)
     .filter((charge) => charge.desk !== 'landscape');
   const isMobile = useMedia('(max-width: 639px)');
   const settingsPath = isMobile ? `${match.url}/:submenu` : '/';

--- a/ui/src/preferences/about-system/AboutSystem.tsx
+++ b/ui/src/preferences/about-system/AboutSystem.tsx
@@ -6,7 +6,7 @@ import { Dialog, DialogClose, DialogContent, DialogTrigger } from '../../compone
 import { FullTlon16Icon } from '../../components/icons/FullTlon16Icon';
 import { useSystemUpdate } from '../../logic/useSystemUpdate';
 import { useCharge } from '../../state/docket';
-import { usePike } from '../../state/kiln';
+import { usePike, useLag } from '../../state/kiln';
 import { disableDefault, pluralize } from '../../state/util';
 import { UpdatePreferences } from './UpdatePreferences';
 
@@ -20,7 +20,9 @@ export const AboutSystem = () => {
   const gardenPike = usePike(window.desk);
   const { systemBlocked, blockedCharges, blockedCount, freezeApps } =
     useSystemUpdate();
+  const gardenBlocked = null != blockedCharges.find(charge => charge.desk == 'garden');
   const hash = gardenPike && getHash(gardenPike);
+  const lag = useLag();
   
   return (
     <>
@@ -46,41 +48,83 @@ export const AboutSystem = () => {
           </div>
           {systemBlocked ? (
             <>
-              <p className="text-orange-500">Update is currently blocked by the following apps:</p>
+            {lag ? (
+              <>
+              <p className="text-orange-500">
+                System update failed because your runtime was out of date.
+              </p>
+              <p>
+                Update your runtime or contact your hosting provider.
+              </p>
+              <p>
+                Once your runtime is up to date, click retry below.
+              </p>
+              <Button variant="caution" onClick={freezeApps}>
+                Retry System Update
+              </Button>
+              </>
+            ) : (blockedCount == 0) ? (
+              <>
+              <p className="text-orange-500">
+                System update failed.
+              </p>
+              <p>
+                For additional debugging output, open the terminal and click retry below.
+              </p>
+              <Button variant="caution" onClick={freezeApps}>
+                Retry System Update
+              </Button>
+              </>
+            ) : (
+              <>
+              <p className="text-orange-500">
+                Update is currently blocked by the following {pluralize('app', blockedCount)}:
+              </p>
               <AppList
                 apps={blockedCharges}
                 labelledBy="blocked-apps"
                 size="xs"
                 className="font-medium"
               />
-              <Dialog>
-                <DialogTrigger as={Button} variant="caution">
-                  Freeze {blockedCount} {pluralize('app', blockedCount)} and Apply Update
-                </DialogTrigger>
-                <DialogContent
-                  showClose={false}
-                  onOpenAutoFocus={disableDefault}
-                  className="space-y-6 tracking-tight"
-                  containerClass="w-full max-w-md"
-                >
-                  <h2 className="h4">
-                    Freeze {blockedCount} {pluralize('App', blockedCount)} and Apply System Update
-                  </h2>
-                  <p>
-                    The following apps will be archived until their developer provides a compatible
-                    update to your system.
-                  </p>
-                  <AppList apps={blockedCharges} labelledBy="blocked-apps" size="xs" />
-                  <div className="flex space-x-6">
-                    <DialogClose as={Button} variant="secondary">
-                      Cancel
-                    </DialogClose>
-                    <DialogClose as={Button} variant="caution" onClick={freezeApps}>
-                      Freeze Apps
-                    </DialogClose>
-                  </div>
-                </DialogContent>
-              </Dialog>
+              {gardenBlocked ? (
+                <>
+                <p>
+                  Grid is the application launcher and system interface.
+                  It needs an update before you can apply the System Update.
+                </p>
+                </>
+              ) : (
+                <Dialog>
+                  <DialogTrigger as={Button} variant="caution">
+                    Suspend {blockedCount} {pluralize('App', blockedCount)} and Apply Update
+                  </DialogTrigger>
+                  <DialogContent
+                    showClose={false}
+                    onOpenAutoFocus={disableDefault}
+                    className="space-y-6 tracking-tight"
+                    containerClass="w-full max-w-md"
+                  >
+                    <h2 className="h4">
+                      Suspend {blockedCount} {pluralize('App', blockedCount)} and Apply System Update
+                    </h2>
+                    <p>
+                      The following {pluralize('app', blockedCount)} will be suspended until their
+                      developer provides an update.
+                    </p>
+                    <AppList apps={blockedCharges} labelledBy="blocked-apps" size="xs" />
+                    <div className="flex space-x-6">
+                      <DialogClose as={Button} variant="secondary">
+                        Cancel
+                      </DialogClose>
+                      <DialogClose as={Button} variant="caution" onClick={freezeApps}>
+                        Suspend {pluralize('App', blockedCount)} and Update
+                      </DialogClose>
+                    </div>
+                  </DialogContent>
+                </Dialog>
+              )}
+              </>
+            )}
             </>
           ) : (
             <p>Your urbit is up to date.</p>


### PR DESCRIPTION
- Recognize if a kelvin update failed and present a "retry" button.
- Recognize if that failure was due to an out-of-date binary and instruct the user to update their binary.
- Disallow system updates if grid is blocked, and inform the user.
- Update copy throughout system update page to be more consistent and clear.
- Change the displayed name from "System" to "Grid".  "System" was ambiguously used for %garden and %base, and this caused no end of confusion.
- Update the "submit issue" link target from urbit/landscape (doesn't exist) to tloncorp/landscape-apps

Paired with @zalberico to make these changes.  I tried to match the JS style to the surrounding code, I have no opinion on how it's factored.

This shows most of the error states you could hit (I don't show the success at the end because it takes a couple minutes to compile):

https://user-images.githubusercontent.com/5553176/210452277-b0f2d58c-354a-4a47-86aa-139279277b63.mp4
