### PR TITLE
preferences: rename grid to landscape in sidebar and update copy

### DIFF
--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -1,4 +1,4 @@
-:~  title+'Grid'
+:~  title+'Landscape'
     info+'An app launcher for Urbit.'
     color+0xee.5432
     glob-http+['https://bootstrap.urbit.org/glob-0v7.kpsc5.0d368.agolo.24l20.b45sb.glob' 0v7.kpsc5.0d368.agolo.24l20.b45sb]

--- a/ui/src/preferences/about-system/AboutSystem.tsx
+++ b/ui/src/preferences/about-system/AboutSystem.tsx
@@ -84,7 +84,7 @@ export const AboutSystem = () => {
               {gardenBlocked ? (
                 <>
                 <p>
-                  Grid is the application launcher and system interface.
+                  Landscape is the application launcher and system interface.
                   It needs an update before you can apply the System Update.
                 </p>
                 </>


### PR DESCRIPTION
In "Installed App Settings" change the name of the App Launcher from Grid to Landscape.

This PR also updates the kelvin update copy for the case when Landscape is blocking base from updating.